### PR TITLE
fix name from Observaciones to observaciones

### DIFF
--- a/src/Model/CpeStatus.php
+++ b/src/Model/CpeStatus.php
@@ -73,7 +73,7 @@ class CpeStatus implements ModelInterface, ArrayAccess
         'estado_cp' => 'estadoCp',
         'estado_ruc' => 'estadoRuc',
         'cond_domi_ruc' => 'condDomiRuc',
-        'observaciones' => 'Observaciones'
+        'observaciones' => 'observaciones'
     ];
 
     /**


### PR DESCRIPTION
There is an error with the name of property "Observaciones" with "o" upperCase, the method deserialize doesn't find the name of property properly.